### PR TITLE
revert: restore codebase to v1.0-stable-pre-tour state

### DIFF
--- a/app/dashboard/create-link/page.tsx
+++ b/app/dashboard/create-link/page.tsx
@@ -1,69 +1,38 @@
 // app/dashboard/create-link/page.tsx
+"use client";
+
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
+export const revalidate = 0;
 
-import { getServerSession } from "next-auth/next";
-import type { Session } from "next-auth";
-import { redirect } from "next/navigation";
-import { authOptions } from "@/lib/auth/options";
-
-import Link from "next/link";
-import DashboardPageHeader from "@/components/DashboardPageHeader";
-
-type AppUser = {
-  id?: string;
-  email?: string;
-  name?: string;
-  role?: string;
-};
-
-export default async function CreateSmartLinkPage() {
-  const session = (await getServerSession(authOptions)) as Session | null;
-  if (!session) {
-    redirect("/api/auth/signin?callbackUrl=/dashboard/create-link");
-  }
-
-  const user = (session?.user ?? {}) as AppUser;
-  const name = user?.email ? user.email.split("@")[0] : user?.name ?? "there";
-
+export default function CreateLinkPage() {
   return (
-    <main className="mx-auto max-w-6xl space-y-6 p-6">
-      {/* Top bar: Back to Smart Links + quick hop to Merchants */}
-      <div className="flex items-center justify-between">
-        <Link
-          href="/dashboard/links"
-          className="inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs text-gray-800 hover:bg-gray-50"
-        >
-          ← Back to Smart Links
-        </Link>
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Create Smart Link</h1>
+      <p className="text-sm text-gray-600">
+        Paste a product URL or choose a merchant to generate a tracked, compliant link.
+      </p>
 
-        <Link
-          href="/dashboard/merchants"
-          className="inline-flex items-center rounded-lg border px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
-        >
-          Explore Merchants
-        </Link>
+      {/* Placeholder form (you can wire this up later) */}
+      <div className="max-w-xl border rounded-2xl p-4 shadow-sm">
+        <label className="block text-sm font-medium mb-1">Product URL</label>
+        <input
+          type="url"
+          placeholder="https://example.com/product/123"
+          className="w-full rounded-lg border px-3 py-2 mb-3"
+        />
+
+        <label className="block text-sm font-medium mb-1">Notes (optional)</label>
+        <textarea
+          placeholder="Campaign notes…"
+          className="w-full rounded-lg border px-3 py-2 mb-4"
+          rows={4}
+        />
+
+        <button className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700">
+          Generate Link
+        </button>
       </div>
-
-      <DashboardPageHeader
-        title="Create Smart Link"
-        subtitle={`Set up a trackable link · Welcome, ${name}`}
-      />
-
-      {/* ======= YOUR CREATE-LINK UI GOES HERE ======= */}
-      {/* Keep this section minimal to avoid changing behavior.
-          If you already have a form/component, it will continue to render here.
-          Otherwise you can replace the placeholder with your existing form. */}
-      <section className="rounded-2xl border bg-white p-4 sm:p-5">
-        <h2 className="text-base font-medium sm:text-lg">Smart Link builder</h2>
-        <p className="mt-2 text-sm text-gray-600">
-          Paste a product or merchant URL to generate a trackable Smart Link. You can also jump to
-          “Explore Merchants” to pick from approved programs.
-        </p>
-
-        {/* If you already have a form component, render it here, e.g.:
-            <CreateSmartLinkForm />  */}
-      </section>
-    </main>
+    </div>
   );
 }

--- a/app/dashboard/links/page.tsx
+++ b/app/dashboard/links/page.tsx
@@ -31,14 +31,6 @@ export default async function SmartLinksPage() {
       <DashboardPageHeader
         title="Smart Links"
         subtitle={`Create and manage links · Welcome back, ${name}`}
-        rightSlot={
-          <Link
-            href="/dashboard/merchants"
-            className="inline-flex items-center rounded-lg border px-3 py-2 text-sm text-gray-800 hover:bg-gray-50"
-          >
-            Explore Merchants
-          </Link>
-        }
       />
 
       {/* Primary actions */}
@@ -48,6 +40,13 @@ export default async function SmartLinksPage() {
           className="inline-flex items-center justify-center rounded-lg bg-green-600 px-4 py-2 text-white hover:bg-green-700"
         >
           Create Smart Link
+        </Link>
+
+        <Link
+          href="/dashboard/merchants"
+          className="inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+        >
+          Explore Merchants
         </Link>
       </div>
 

--- a/app/dashboard/merchants/page.tsx
+++ b/app/dashboard/merchants/page.tsx
@@ -4,12 +4,10 @@ export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
 
 import React from "react";
-import Link from "next/link";
 import { headers, cookies } from "next/headers";
 import { prisma } from "@/lib/db";
 import AdminDeleteMerchantButton from "@/components/AdminDeleteMerchantButton";
 import DashboardPageHeader from "@/components/DashboardPageHeader";
-import AISuggestionsClient from "./AISuggestionsClient";
 
 type MerchantDTO = {
   id: string;
@@ -133,16 +131,6 @@ export default async function MerchantsPage() {
   if (!data?.ok) {
     return (
       <div className="p-6">
-        {/* Back link */}
-        <div className="mb-3">
-          <Link
-            href="/dashboard/links"
-            className="inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs text-gray-800 hover:bg-gray-50"
-          >
-            ← Back to Smart Links
-          </Link>
-        </div>
-
         <h1 className="text-2xl font-semibold mb-2">Merchants</h1>
         <p className="text-sm text-red-600">
           Failed to load merchant rules{data?.error ? ` — ${data.error}` : ""}.
@@ -156,16 +144,6 @@ export default async function MerchantsPage() {
 
   return (
     <div className="p-6 space-y-6">
-      {/* Back link */}
-      <div>
-        <Link
-          href="/dashboard/links"
-          className="inline-flex items-center gap-1 rounded-lg border px-2.5 py-1 text-xs text-gray-800 hover:bg-gray-50"
-        >
-          ← Back to Smart Links
-        </Link>
-      </div>
-
       <DashboardPageHeader
         title="Merchants"
         subtitle={admin ? "Admin view · All regions" : `Your market: ${market} · Region-filtered`}
@@ -175,9 +153,6 @@ export default async function MerchantsPage() {
           </span>
         }
       />
-
-      {/* ✨ AI Suggestions (beta) */}
-      <AISuggestionsClient />
 
       <section className="rounded-xl border bg-white">
         <div className="flex items-center justify-between px-3 sm:px-4 py-3 sm:py-4">


### PR DESCRIPTION
Rolling back to the last stable pre-tour baseline.
- Removes recent edits that changed navigation/layout
- Restores dashboard, links, merchants, and other pages to stable state
- Keeps DB/schema untouched
